### PR TITLE
Properly link to BLAS on all platforms

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+PKG_LIBS = $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,0 @@
-PKG_LIBS = $(BLAS_LIBS)


### PR DESCRIPTION
This fixes cross the cross compile: https://github.com/r-universe/phylotastic/actions/runs/7489721657/job/20387069388